### PR TITLE
Support Apollo MockLink

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-mocked",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "main": "dist/index.js",
   "umd:main": "dist/apollo-mocked.umd.production.js",
   "module": "dist/apollo-mocked.es.production.js",
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@apollo/react-hooks": "^3.1.1",
+    "@apollo/react-testing": "^3.1.1",
     "apollo-cache-inmemory": "^1.6.3",
     "apollo-client": "^2.6.4",
     "graphql": "^14.5.7",

--- a/src/ApolloMockedProvider.tsx
+++ b/src/ApolloMockedProvider.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { ApolloProvider } from '@apollo/react-hooks';
+import { MockedResponse } from '@apollo/react-testing';
 import { IMocks } from 'graphql-tools';
 import { IntrospectionQuery } from 'graphql';
 import { createApolloClient } from './utils';
 
 export interface ApolloMockedProviderProps {
-  mocks: IMocks;
-  introspectionResult: IntrospectionQuery | any;
+  mocks: IMocks | ReadonlyArray<MockedResponse>;
+  introspectionResult?: IntrospectionQuery | any;
 }
 
 export const ApolloMockedProvider: React.FC<ApolloMockedProviderProps> = ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,15 @@
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
 
+"@apollo/react-testing@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@apollo/react-testing/-/react-testing-3.1.1.tgz#27a8fb268604f785cf7c1d284a734acfbe039e05"
+  integrity sha512-tjZ5zQ8WRSu4gXCfhNWDt3rgsunFZ7QapyDNp9ykVIuC/JrusUdbGieq9PajZsmLZUMOfQUEEoWBNRWNAsXlJw==
+  dependencies:
+    "@apollo/react-common" "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    tslib "^1.10.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"


### PR DESCRIPTION
- adds @apollo/react-testing dependency
- introspectionResult prop now optional
- mocks prop support both apollo-link with introspection or mock-link
- add util for creating mocks for mock link
- bump version