### PR TITLE
fix: graphql dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-mocked",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "main": "dist/index.js",
   "umd:main": "dist/apollo-mocked.umd.production.js",
   "module": "dist/apollo-mocked.es.production.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ import {
   GraphQLError,
   GraphQLSchema,
   IntrospectionQuery,
-  introspectionQuery,
+  getIntrospectionQuery,
   print,
   printSchema,
 } from 'graphql';
@@ -44,7 +44,7 @@ export async function fetchGraphQLSchema(
       ...headers,
     },
     body: JSON.stringify({
-      query: introspectionQuery,
+      query: getIntrospectionQuery,
     }),
     ...init,
   })


### PR DESCRIPTION
- replace usage of `introspectionQuery` with `getIntrospectionQuery`
- bump version
