### PR TITLE
Fix/apollo mocked provider interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-mocked",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "main": "dist/index.js",
   "module": "dist/apollo-mocked.esm.js",
   "typings": "dist/index.d.ts",

--- a/src/ApolloMockedProvider.tsx
+++ b/src/ApolloMockedProvider.tsx
@@ -1,18 +1,8 @@
 import * as React from 'react';
-import {
-  ApolloClientOptions,
-  ApolloProvider,
-  InMemoryCacheConfig,
-  NormalizedCacheObject,
-} from '@apollo/client';
-import { MockedResponse } from '@apollo/client/testing';
-import { createApolloClient, LinkSchemaProps } from './utils';
+import { ApolloProvider } from '@apollo/client';
+import { CreateApolloClient, createApolloClient } from './utils';
 
-export interface ApolloMockedProviderProps {
-  mocks: ReadonlyArray<MockedResponse> | LinkSchemaProps;
-  addTypename?: boolean;
-  cacheOptions?: InMemoryCacheConfig;
-  clientOptions?: ApolloClientOptions<NormalizedCacheObject>;
+export interface ApolloMockedProviderProps extends CreateApolloClient {
   Provider?: React.ComponentType<any>;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,7 +135,7 @@ export interface LinkSchemaProps extends CreateLinkOptions {
   context?: any;
 }
 
-interface CreateApolloClient {
+export interface CreateApolloClient {
   mocks: ReadonlyArray<MockedResponse> | LinkSchemaProps;
   cacheOptions?: InMemoryCacheConfig;
   clientOptions?: ApolloClientOptions<NormalizedCacheObject>;
@@ -165,7 +165,7 @@ export function createApolloClient({
       delay,
     } = mocks as LinkSchemaProps;
 
-    const schema = buildClientSchema(introspectionResult as any);
+    const schema = buildClientSchema(introspectionResult);
     let mockOptions: any = { schema };
 
     mockOptions = {


### PR DESCRIPTION
The `link` prop was unintentionally removed from the `ApolloMockedProvider` interface. Now just extending `CreateApolloClient` type which includes all relevant fields.